### PR TITLE
force pdfjs to 1.3.78 until issue with 1.3.94 is resolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/erikras/react-pdfjs",
   "dependencies": {
-    "pdfjs-dist": "^1.3.44"
+    "pdfjs-dist": "1.3.78"
   },
   "devDependencies": {
     "babel": "^5.8.23",


### PR DESCRIPTION
pdfjs-dist 1.3.94 breaks (seemingly) due to a webpack issue??

Can we fix the pdfjs-dist version to 1.3.78 for now?
