### PR TITLE
Adding checks for changed scale prop in src/Pdf.js to zoom dynamically

### DIFF
--- a/src/Pdf.js
+++ b/src/Pdf.js
@@ -12,8 +12,6 @@ class Pdf extends Component {
     this.state = {};
   }
 
-  // state = {};
-
   componentDidMount() {
     this.loadPDFDocument(this.props);
     this.renderPdf();
@@ -25,10 +23,7 @@ class Pdf extends Component {
       (newProps.content && newProps.content !== this.props.content)) {
       this.loadPDFDocument(newProps);
     }
-    // if (pdf && newProps.page && newProps.page !== this.props.page) {
-    //   this.setState({page: null});
-    //   pdf.getPage(newProps.page).then(this.onPageComplete);
-    // }
+
     if (pdf && ((newProps.page && newProps.page !== this.props.page) ||
       (newProps.scale && newProps.scale !== this.props.scale))) {
       this.setState({page: null});

--- a/src/Pdf.js
+++ b/src/Pdf.js
@@ -27,7 +27,7 @@ class Pdf extends Component {
     if (pdf && ((newProps.page && newProps.page !== this.props.page) ||
       (newProps.scale && newProps.scale !== this.props.scale))) {
       this.setState({page: null});
-      pdf.getPage(newProps.page).then(this.onPageComplete)
+      pdf.getPage(newProps.page).then(this.onPageComplete);
     }
   }
 

--- a/src/Pdf.js
+++ b/src/Pdf.js
@@ -9,9 +9,10 @@ class Pdf extends Component {
     super(props);
     this.onDocumentComplete = this.onDocumentComplete.bind(this);
     this.onPageComplete = this.onPageComplete.bind(this);
+    this.state = {};
   }
 
-  state = {};
+  // state = {};
 
   componentDidMount() {
     this.loadPDFDocument(this.props);
@@ -24,9 +25,14 @@ class Pdf extends Component {
       (newProps.content && newProps.content !== this.props.content)) {
       this.loadPDFDocument(newProps);
     }
-    if (pdf && newProps.page && newProps.page !== this.props.page) {
+    // if (pdf && newProps.page && newProps.page !== this.props.page) {
+    //   this.setState({page: null});
+    //   pdf.getPage(newProps.page).then(this.onPageComplete);
+    // }
+    if (pdf && ((newProps.page && newProps.page !== this.props.page) ||
+      (newProps.scale && newProps.scale !== this.props.scale))) {
       this.setState({page: null});
-      pdf.getPage(newProps.page).then(this.onPageComplete);
+      pdf.getPage(newProps.page).then(this.onPageComplete)
     }
   }
 


### PR DESCRIPTION
Hi,

for a project i'm working on I needed the ability to zoom pdfs. Since you only check for `newProps.page`in https://github.com/erikras/react-pdfjs/blob/master/src/Pdf.js#l27 i've added checks for changed scale prop. It would be great if you could merge it.

Also thanks to the original author, @nnarhinen.
