### PR TITLE
Fixes a bug where changing to a rotate of 0 does not cause a rerender.

### DIFF
--- a/src/Pdf.js
+++ b/src/Pdf.js
@@ -28,7 +28,7 @@ class Pdf extends Component {
 
     if (pdf && ((newProps.page && newProps.page !== this.props.page) ||
       (newProps.scale && newProps.scale !== this.props.scale)) ||
-      ((newProps.rotate || newProps.rotate !== 0) && newProps.rotate !== this.props.rotate)) {
+      ((newProps.rotate || newProps.rotate === 0) && newProps.rotate !== this.props.rotate)) {
       this.setState({page: null});
       pdf.getPage(newProps.page).then(this.onPageComplete);
     }

--- a/src/Pdf.js
+++ b/src/Pdf.js
@@ -28,7 +28,7 @@ class Pdf extends Component {
 
     if (pdf && ((newProps.page && newProps.page !== this.props.page) ||
       (newProps.scale && newProps.scale !== this.props.scale)) ||
-      (newProps.rotate && newProps.rotate !== this.props.rotate)) {
+      ((newProps.rotate || newProps.rotate !== 0) && newProps.rotate !== this.props.rotate)) {
       this.setState({page: null});
       pdf.getPage(newProps.page).then(this.onPageComplete);
     }


### PR DESCRIPTION
Presently passing in a rotate of 0 never causes a rerender. This change will make it so that a rerender will happen whenever the rotate prop changes and it is truthy or zero.